### PR TITLE
Fix for curried function shorthand.

### DIFF
--- a/base.rkt
+++ b/base.rkt
@@ -173,7 +173,7 @@
     (syntax-case stx ()
       [(_ (f . args) body0 body ...)
        (quasisyntax/loc stx
-         (define f 
+         (~define f 
            (lazy-proc
             #,(attach-inferred-name
                #'(lambda args (~begin body0 body ...))

--- a/tests/lang.rkt
+++ b/tests/lang.rkt
@@ -25,6 +25,14 @@
    (! (= 1.0 1)) => #t
    (! (equal? (list 1.0) (list 1.0))) => #t
    (! (letrec ([zs (cons 0 zs)]) (equal? (list zs zs) (list zs zs)))) => #t
+   (! (let () ; this tests functions defined with the curried function shorthand
+        (define acc 0)
+
+        (define (((iffn cond) iftrue) iffalse)
+          (if cond iftrue iffalse))
+
+        (((iffn (< 1 1)) (set! acc (+ acc 1))) (set! acc (+ acc 1)))
+        acc)) => 1
    ))
 
 (define (list-tests)

--- a/tests/lang.rkt
+++ b/tests/lang.rkt
@@ -168,7 +168,7 @@
   ; function used in tests for curried functions defined with
   ; the shorthand syntax
   (define (((iffn cond) iftrue) iffalse)
-          (if cond iftrue iffalse))
+    (if cond iftrue iffalse))
   (test
    (! (and (/ 1 0))) =error> "/: division by zero"
    (! (and #f (/ 1 0))) => #f

--- a/tests/lang.rkt
+++ b/tests/lang.rkt
@@ -25,14 +25,6 @@
    (! (= 1.0 1)) => #t
    (! (equal? (list 1.0) (list 1.0))) => #t
    (! (letrec ([zs (cons 0 zs)]) (equal? (list zs zs) (list zs zs)))) => #t
-   (! (let () ; this tests functions defined with the curried function shorthand
-        (define acc 0)
-
-        (define (((iffn cond) iftrue) iffalse)
-          (if cond iftrue iffalse))
-
-        (((iffn (< 1 1)) (set! acc (+ acc 1))) (set! acc (+ acc 1)))
-        acc)) => 1
    ))
 
 (define (list-tests)
@@ -173,6 +165,10 @@
    (!! (take 10 F)) => '(0 0 1 0 2 1 3 0 4 2)))
 
 (define (strictness-tests)
+  ; function used in tests for curried functions defined with
+  ; the shorthand syntax
+  (define (((iffn cond) iftrue) iffalse)
+          (if cond iftrue iffalse))
   (test
    (! (and (/ 1 0))) =error> "/: division by zero"
    (! (and #f (/ 1 0))) => #f
@@ -208,6 +204,10 @@
    (! (andmap (/ 1 0) '())) =error> "/: division by zero"
    (! (andmap (/ 1 0) '(1))) =error> "/: division by zero"
    (! (andmap 1 (/ 1 0))) =error> "/: division by zero"
+   (! (((iffn #f) (/ 1 0)) 1)) => 1
+   (! (((iffn #t) (/ 1 0)) 1)) =error> "/: division by zero"
+   (! (((iffn #f) 1) (/ 1 0))) =error> "/: division by zero"
+   (! (((iffn #t) 1) (/ 1 0))) => 1
    ))
 
 (define (values-tests)


### PR DESCRIPTION
When working with `#lang lazy` I found out I can not use the curried function shorthand. A small example can be seen below - `fac2` will not terminate. I asked on Discord about this problem and Alex Knauth directly [replied](https://discord.com/channels/571040468092321801/1089218827268673657/1281246608134115349) with the solution.

```racket
#lang lazy

(define (Y f)
  ((λ (x) (f (x x)))
   (λ (x) (f (x x)))))

(define (yfac self) (λ (n)
  (if (< n 2)
      n
      (* n (self (- n 1))))))

(define ((yfac2 self) n)
  (if (< n 2)
      n
      (* n (self (- n 1)))))

(define fac1 (Y yfac))
(define fac2 (Y yfac2))

(fac1 5)

; boom
(fac2 5)
```

This PR implements the fix - the issue is gone and no tests are failing.